### PR TITLE
Added publishing file group tag for config file

### DIFF
--- a/src/ModulesServiceProvider.php
+++ b/src/ModulesServiceProvider.php
@@ -19,7 +19,7 @@ class ModulesServiceProvider extends ServiceProvider
 	{
 		$this->publishes([
 			__DIR__.'/../config/modules.php' => config_path('modules.php'),
-		]);
+		], 'config');
 
 		$this->app['modules']->register();
 	}


### PR DESCRIPTION
Added publishing file group tag for config file so we can use ```php artisan vendor:publish --tag=config```, as suggested in [Package Development - Publishing File Groups](http://laravel.com/docs/5.1/packages#publishing-file-groups)